### PR TITLE
Support laravel 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
             testbench: '5.*'
           - laravel: '8.*'
             testbench: '6.*'
+          - laravel: '8.*'
+            testbench: '7.*'
           - es: '7.11.2'
             es-php: '7.11.*'
           - es: '7.12.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             testbench: '5.*'
           - laravel: '8.*'
             testbench: '6.*'
-          - laravel: '8.*'
+          - laravel: '9.*'
             testbench: '7.*'
           - es: '7.11.2'
             es-php: '7.11.*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         php:
           - '7.4'
           - '8.0'
+          - '8.1'
         es:
           - '7.11.2'
           - '7.12.1'
@@ -29,6 +30,7 @@ jobs:
         laravel:
           - 7.*
           - 8.*
+          - 9.*
         prefer:
           # - 'prefer-lowest'
           - 'prefer-stable'
@@ -45,6 +47,9 @@ jobs:
             es-php: '7.13.*'
           - es: '7.14.1'
             es-php: '7.14.*'
+        exclude:
+          - php: '7.4'
+          - laravel: '9.*'
 
     name: PHP ${{ matrix.php }} - ES ${{ matrix.es }} Laravel ${{ matrix.laravel }} --${{ matrix.prefer }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
             es-php: '7.14.*'
         exclude:
           - php: '7.4'
-          - laravel: '9.*'
+            laravel: '9.*'
+          - php: '8.1'
+            laravel: '7.*'
 
     name: PHP ${{ matrix.php }} - ES ${{ matrix.es }} Laravel ${{ matrix.laravel }} --${{ matrix.prefer }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "aws/aws-sdk-php": "^3.200",
         "guzzlehttp/guzzle": "^6.5|^7.3",
         "guzzlehttp/ring": "^1.1.1",
-        "illuminate/support": "^7.40|^8.40"
+        "illuminate/support": "^7.40|^8.40|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Please see the issue I opened at #46. It looks like this utility can support Laravel 9. I added Laravel 9 and PHP 8.1 to the tests after adding `illuminate/support:^9.0` to composer.json and the [tests are passing](https://github.com/enderandpeter/aws-elastic-client/actions/runs/2498100258). Please take a look and let me know what you think. Thank you.